### PR TITLE
Update Kamban.csproj to support  VS2019

### DIFF
--- a/KambanSolution/Kamban/Kamban.csproj
+++ b/KambanSolution/Kamban/Kamban.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LanguageTargets>$(MSBuildExtensionsPath)\$(VisualStudioVersion)\Bin\Microsoft.CSharp.targets</LanguageTargets>
+    <LanguageTargets>$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Bin\Microsoft.CSharp.targets</LanguageTargets>
     <TargetFramework>net462</TargetFramework>
     <OutputType>WinExe</OutputType>
     <RootNamespace>Kamban</RootNamespace>


### PR DESCRIPTION
When building this project in VS2019, the build engine can't find the specified Microsoft.CSharp.targets file. Since starting in VS2019, MSBuild will use "Current" instead of the major version number as part of its path. For vs2019, the $(VisualStudioVersion) is 16.0, but it doesn't exists $(MSBuildExtensionsPath)\16.0 directory, it only exists $(MSBuildExtensionsPath)\Current directory. So I suggest replace $(VisualStudioVersion) with $(MSBuildToolsVersion). For vs2017, they all represents 15.0. For vs2019, $(VisualStudioVersion)=16.0 while $(MSBuildToolsVersion)=Current. So use $(MSBuildToolsVersion) to support for both VS2017 and VS2019. Please check it :)